### PR TITLE
docs(oss): add LICENSE/NOTICE/OSS policy + repo hygiene files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Kontribusi
+- Runtime: Node 20.x + pnpm 9
+- Alur: feature/<nama> → PR → CI lulus → squash merge
+- Konvensi commit: Conventional Commits (feat|fix|chore|docs)
+- Perintah inti:
+  pnpm install
+  pnpm dev
+  pnpm lint
+  pnpm typecheck
+  pnpm test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2025 EduLite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+EduLite © 2025.
+Produk ini menyertakan perangkat lunak pihak ketiga berlisensi OSS.
+Lihat THIRD_PARTY_LICENSES.md untuk rincian atribusi.

--- a/OSS.md
+++ b/OSS.md
@@ -1,0 +1,22 @@
+# Kebijakan OSS EduLite
+
+## Prinsip
+- Gunakan paket via pnpm; jangan vendor/commit source upstream.
+- Fork hanya bila patch jangka panjang diperlukan; dokumentasikan di bagian "Fork".
+- Penuhi kewajiban lisensi & atribusi.
+
+## Lisensi yang diizinkan (allowlist)
+MIT, Apache-2.0, BSD-2/3-Clause, ISC, MPL-2.0.
+Dihindari di klien: GPL-3.0, AGPL-3.0.
+
+## Proses menambah dependensi
+1) Pastikan lisensi cocok allowlist.
+2) `pnpm add <pkg>` atau `pnpm add -D <pkg>`.
+3) Jalankan `pnpm sbom` dan `pnpm licenses:gen`.
+4) Tambahkan atribusi wajib ke `NOTICE` bila diperlukan.
+
+## Fork yang dipertahankan
+- (kosong)
+
+## Atribusi pihak ketiga
+- Font/ikon, dsb — dirangkum di `THIRD_PARTY_LICENSES.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Keamanan
+Laporkan kerentanan ke: security@edulite.local
+Target respons awal: 72 jam. Perbaikan kritikal: 7 hari.
+Jangan commit rahasia (.env). Simpan rahasia di Vercel/Secrets Manager.


### PR DESCRIPTION
## Ringkasan
Batch 1: menambahkan berkas hygiene & kebijakan OSS-first untuk repo EduLite.

### Perubahan utama
- LICENSE (MIT)
- NOTICE (atribusi umum)
- .editorconfig
- .env.example (template environment, tidak berisi rahasia)
- OSS.md (kebijakan OSS)
- SECURITY.md (proses laporan kerentanan)
- CONTRIBUTING.md (aturan kontribusi & commit)
- Update README.md
- Update package.json (scripts dev, lint, typecheck, test, sbom, licenses:gen)

### Alasan / Manfaat
- Fondasi OSS-first: kepatuhan lisensi & dokumentasi.
- Standarisasi kontribusi & env.
- Menyiapkan langkah lanjut (Batch 2: shared configs; Batch 3: CI).

### Checklist
- [x] Lisensi MIT terpasang
- [x] Template env tersedia
- [x] Kebijakan OSS terdokumentasi
- [x] Tidak ada rahasia yang ikut commit
